### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
   "perl": "6.c",
   "name": "Serialize::Naive",
+  "license" : "Artistic-2.0",
   "version": "0.2.4",
   "description": "A somewhat naive (de-)serialization implementation",
   "authors": [ "Peter Pentchev" ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license