### PR TITLE
`use v6.c` must be on the first line

### DIFF
--- a/lib/Serialize/Naive.pm6
+++ b/lib/Serialize/Naive.pm6
@@ -1,6 +1,6 @@
-unit role Serialize::Naive:ver<0.2.5>:auth<github:ppentchev>;
-
 use v6.c;
+
+unit role Serialize::Naive:ver<0.2.5>:auth<github:ppentchev>;
 
 sub get-type-name($type)
 {


### PR DESCRIPTION
Upcoming rakudo releases will complain about it.